### PR TITLE
Add support for configuration file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,10 +5,21 @@ Cookiecutter template for a python project. See https://github.com/audreyr/cooki
 
 * Free software: MIT license
 * Click_: Create beautiful command line interfaces
-* pbr_: Set up to use Python Build Reasonableness
+* PBR_: Set up to use Python Build Reasonableness
 * Pytest_: Better unit testing
-* Tox_ testing: Setup to easily test for Python 2.7, 3.5
+* Tox_ testing: Easily setup tests for Python 3.5, 3.6
 * Sphinx_ docs: Documentation ready for generation and publication
+* All the administrative tasks are defined in the `Makefile`
+* Docker_: Containerize the project
+* coala_: Implement static analyzers through the use of
+  * Git Commit format checker
+  * Pin Requirements checker
+  * Pycodestyle
+  * PyDocStyle
+  * PyFlakes
+  * PyLint
+
+* Anyconfig_ to read and validate the configuration file
 
 Usage
 -----
@@ -29,8 +40,11 @@ Then:
 * Check that the versions in the requirements match your needs. They might be a bit old by the time you use this cookiecutter.
 * Add the project to your GitHub account.
 
+.. _Anyconfig: https://github.com/ssato/python-anyconfig
 .. _Click: http://click.pocoo.org/6/
-.. _pbr: http://docs.openstack.org/developer/pbr
+.. _coala: https://coala.io/
+.. _Docker: https://www.docker.com/
+.. _PBR: http://docs.openstack.org/developer/pbr
 .. _Pytest: https://docs.pytest.org/en/latest/
 .. _Tox: http://testrun.org/tox/
 .. _Sphinx: http://sphinx-doc.org/

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,9 +1,10 @@
 {
-	"repo_name": "replace with the name for the git repo",
-	"project_short_description": "Describe your project in one line.",
-	"author": "put your name here",
-	"author_email": "put your name here",
-	"version": "0.1.0",
+	"repo_name": "Name for the git repo",
+	"project_short_description": "Describe your project in one line",
+  "prefix": "Short prefix to use for the project (i.e. 'ORG')",
+	"author": "Put your name here",
+	"author_email": "Put your email here",
+	"version": "0.0.1",
 	"year": "2017",
 	"license": "MIT"
 }

--- a/{{cookiecutter.repo_name}}/Dockerfile
+++ b/{{cookiecutter.repo_name}}/Dockerfile
@@ -4,10 +4,7 @@ MAINTAINER Rémy Greinhofer <remy.greinhofer@gmail.com>
 # Install system packages.
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-
     git \
-
-  # Cleaning up.
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/{{cookiecutter.repo_name}}/requirements/_base.txt
+++ b/{{cookiecutter.repo_name}}/requirements/_base.txt
@@ -1,3 +1,4 @@
+anyconfig==0.9.3
 click==6.7
 pbr==3.1.1
 tabulate==0.8.1

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/cli/cli.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/cli/cli.py
@@ -1,8 +1,11 @@
 """Define the top-level cli command."""
+import os
+
 import click
 from pbr import version
 
 from {{ cookiecutter.repo_name }}.cli.base import AbstractCommand
+from {{ cookiecutter.repo_name }} import config
 
 # Retrieve the project version from PBR.
 try:
@@ -11,6 +14,7 @@ try:
 except AttributeError:
     __version__ = None
 
+APP_NAME = '{{ cookiecutter.repo_name }}'
 
 @click.group()
 @click.version_option(version=__version__)
@@ -25,6 +29,12 @@ except AttributeError:
 def cli(ctx, log_level):
     """Manage CLI commands."""
     ctx.obj = {**ctx.params}
+    ctx.auto_envvar_prefix = '{{ cookiecutter.prefix|upper }}'
+
+    # Load defaults from configuration file if any.
+    cfg_path = os.path.join(click.get_app_dir(APP_NAME), APP_NAME+'.conf')
+    cfg = cfg_path if os.path.exists(cfg_path) else None
+    ctx.default_map = config.load(cfg, with_defaults=True, validate=True)
 
 
 @click.command()
@@ -34,7 +44,7 @@ def hello_world():
 
 
 @click.command()
-@click.argument('name', default='you')
+@click.option('--name')
 @click.pass_context
 def hello(ctx, name):
     """Greet somebody."""

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config.py
@@ -1,0 +1,50 @@
+import os
+
+import anyconfig
+
+CONFIGURATION_DEFAULTS = {'hello': {'name': 'stranger'}}
+
+CONFIGURATION_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'hello': {
+            'type': 'object',
+            'properties': {
+                'name': {
+                    'type': 'string'
+                }
+            }
+        }
+    }
+}
+
+
+def load(path=None, with_defaults=False, validate=False):
+    """
+    Load the configuration.
+
+    :param str path: configuration file path. If set to `None`, it makes the configuration file optional, meaning
+        that either only the defaults will be loaded or that the configuration will be empty. Otherwise the
+        loading will fail if the file is not found.
+    :param bool with_defaults: if `True`, loads the default values when they are not specified in the configuration file
+    :param bool validate: if `True`, validates the configuration. If an error is detected, a `SyntaxError`
+        will be raised. The error message should indicate which part of the configuration file was invalid.
+    :returns: (dict) A dictionary representing the configuration.
+    """
+    # Prepare the configuration dictionary, with the default values if requested.
+    conf = CONFIGURATION_DEFAULTS if with_defaults else {}
+
+    # Load the configuration file if specified.
+    conf_from_file = {} if path is None else anyconfig.load(path)
+
+    # Merge the configuration into the dictionary containing the defaults.
+    # If `with_defaults` is False, this step simply loads the configuration file.
+    anyconfig.merge(conf, conf_from_file)
+
+    # Validate the configuration.
+    if validate:
+        (rc, err) = anyconfig.validate(conf, CONFIGURATION_SCHEMA)
+        if not rc:
+            raise SyntaxError(err)
+
+    return conf


### PR DESCRIPTION
This patch adds support for using a configuration file as well as
validating it with a scheme using `anyconfig`.

The variable precedence will look like this (in priority order):
1. CLI parameter
2. Configuration file
3. Default value

* Fix `Dockerfile` warning: `[WARNING]: Empty continuation lines will
become errors in a future release.`
* Update the README with more details