### PR TITLE
Add CircleCI support

### DIFF
--- a/{{cookiecutter.repo_name}}/.circleci/config.yml
+++ b/{{cookiecutter.repo_name}}/.circleci/config.yml
@@ -1,0 +1,70 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.6.2
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - deps-{{ checksum "requirements/local.txt" }}
+          # fallback to using the latest cache if no exact match is found
+          - deps-
+
+      - run:
+          name: install dependencies
+          command: make venv
+
+      - save_cache:
+          paths:
+            - ./venv
+          key: deps-{{ checksum "requirements/local.txt" }}
+
+
+      # This test is temporary. As of 2017/10/30, a bug in the coala:0.11 docker image prevents us to use the YapfBear
+      # for testing the formating. Therefore the check was added here until they release the next version (and
+      # hopefully fix the issue).
+      - run:
+          name: check the formatting (temporary due to coala bug)
+          command: |
+            . venv/bin/activate
+            tox -e yapf
+
+      - run:
+          name: run unit tests
+          command: |
+            . venv/bin/activate
+            tox
+
+      - store_artifacts:
+          path: test-reports
+          destination: test-reports
+
+      - run:
+          name: run doc tests
+          command: |
+            . venv/bin/activate
+            tox -e docs
+  coala:
+    docker:
+      - image: coala/base:0.11
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+      - run:
+          name: Run coala
+          command: coala --ci
+
+workflows:
+  version: 2
+  gates:
+    jobs:
+      - coala
+      - build

--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -1,7 +1,9 @@
-# Misc.
-PYTHON_EXE = python3
+# Makefile variables.
 SHELL = /bin/bash
+
+# Misc.
 TOPDIR = $(shell git rev-parse --show-toplevel)
+YAPF_EXCLUDE=*.tox/*,*venv/*
 
 # Docker.
 DOCKER_IMAGE = {{ cookiecutter.repo_name }}
@@ -45,10 +47,10 @@ docs: ## Build documentation
 	$(DOCKER_RUN_CMD) sphinx-build -W -b html -d docs/build/doctrees docs/source/ docs/build/html
 
 format: ## Format the codebase using YAPF
-	$(DOCKER_RUN_CMD) yapf -r -i {{ cookiecutter.repo_name }}
+	$(DOCKER_RUN_CMD) yapf -r -i -e{$(YAPF_EXCLUDE)} .
 
 format-check: ## Check the code formatting using YAPF
-	$(DOCKER_RUN_CMD) yapf -r -d {{ cookiecutter.repo_name }}
+	$(DOCKER_RUN_CMD) yapf -r -d -e{$(YAPF_EXCLUDE)} .
 
 setup: docker-build ## Setup the full environment (default)
 
@@ -62,4 +64,4 @@ venv/bin/activate: requirements/local.txt
 wheel: docker-build ## Build a wheel package
 	$(DOCKER_RUN_CMD) python setup.py bdist_wheel
 
-.PHONY: ci-coala ci-docs ci-tests clean docs format format-check service-api setup wheel
+.PHONY: ci-coala ci-docs ci-tests clean docker-build docker-clean docs format format-check service-api setup wheel

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skip_missing_interpreters = true
-envlist=py35,py36
+envlist=py36
 
 [testenv]
 deps = -r{toxinidir}/requirements/testing.txt
@@ -16,9 +16,9 @@ commands =
 
 [testenv:yapf]
 deps =
-  yapf==0.18.0
+  yapf==0.19.0
 commands =
-  yapf -d -i {toxinidir}/{{ cookiecutter.repo_name }}
+  yapf -r -d -e *.tox/* -e *venv/* .
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
Adds a CircleCI configuration file to the cookiecutter.

Drive-by:
* Make YAPF targets more generic