### PR TITLE
Fix Circle CI configuration file

### DIFF
--- a/{{cookiecutter.repo_name}}/.circleci/config.yml
+++ b/{{cookiecutter.repo_name}}/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - deps-{{ checksum "requirements/local.txt" }}
+          - deps-{{ '{{' }} checksum "requirements/local.txt" {{ '}}' }}
           # fallback to using the latest cache if no exact match is found
           - deps-
 
@@ -23,7 +23,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: deps-{{ checksum "requirements/local.txt" }}
+          key: deps-{{ '{{' }} checksum "requirements/local.txt" {{ '}}' }}
 
 
       # This test is temporary. As of 2017/10/30, a bug in the coala:0.11 docker image prevents us to use the YapfBear


### PR DESCRIPTION
A Jinja2 mistake prevented the rendering of the cookiecutter.