### PR TITLE
Fix dynamic version number lookup

### DIFF
--- a/{{cookiecutter.repo_name}}/.coveragerc
+++ b/{{cookiecutter.repo_name}}/.coveragerc
@@ -3,3 +3,4 @@ omit =
     *__init__.py
     {{ cookiecutter.repo_name }}/main.py
     {{ cookiecutter.repo_name }}/tests/*
+    {{ cookiecutter.repo_name }}/cli/cli.py

--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -11,7 +11,7 @@ DOCKER_IMAGE_VERSION ?= $$(git describe)
 DOCKER_IMAGE_FULL = $(DOCKER_IMAGE):$(DOCKER_IMAGE_VERSION)
 
 # External images.
-DOCKER_IMAGE_COALA = coala/base:pre
+DOCKER_IMAGE_COALA = coala/base:0.11
 
 # Docker run command.
 DOCKER_RUN_CMD = docker run -t -v=$$(pwd):/code --rm $(DOCKER_IMAGE_FULL)

--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -38,6 +38,7 @@ testing =
 source-dir = docs/source
 build-dir = docs/build
 all_files = 1
+warning-is-error = 1
 
 [entry_points]
 console_scripts =
@@ -48,7 +49,6 @@ builder = html,text
 skip_authors = True
 skip_changelog = True
 all_files = 1
-warning-is-error = 1
 
 [wheel]
 universal = 0

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/cli/cli.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/cli/cli.py
@@ -7,12 +7,17 @@ from pbr import version
 from {{ cookiecutter.repo_name }}.cli.base import AbstractCommand
 from {{ cookiecutter.repo_name }} import config
 
-# Retrieve the project version from PBR.
+# Retrieve the project version from packaging.
 try:
-    version_info = version.VersionInfo('processor-cli')
-    __version__ = version_info.release_string()
-except AttributeError:
+    try:
+        version_info = version.VersionInfo('{{ cookiecutter.repo_name }}')
+        __version__ = version_info.release_string()
+    except pkg_resources.DistributionNotFound:
+        distribution_info = pkg_resources.get_distribution('pip')
+        __version__ = distribution_info.version
+except Exception:
     __version__ = None
+
 
 APP_NAME = '{{ cookiecutter.repo_name }}'
 


### PR DESCRIPTION
The version number of the application is extracted from the packaging,
but `PBR` can only read it from a source or sdist installation. To fix
that, a fallback using `pip` was implemented.

Drive-bys:
* Remove coverage for the base cli class
* Fix sphinx configuration in `setup.cfg`