### PR TITLE
Fix keyword colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move the tests directory to the root of the project.
 - Restructure the documentation in a more sensible way.
 - Use the [aiohttp](https://github.com/aio-libs/aiohttp-theme) theme for the documentation.
+- Use a custom CSS file to emphasize keywords in the reference documentation and keywords between backticks.
+
+### Fixed
+
+- Fix the `Makefile` to prevent the `venv` target to run unnecessarily.
 
 ### Removed
 

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -92,12 +92,12 @@ test: venv ## Run the unit tests
 
 setup: venv ## Setup the full environment (default)
 
-venv: venv/bin/activate ## Setup local venv
+venv: venv/bin/python ## Setup local venv
 	echo "[ -f $(VENV_BIN)/postactivate ] && . $(VENV_BIN)/postactivate" >> $(VENV_BIN)/activate
 	echo "export PYTHONBREAKPOINT=bpdb.set_trace" > $(VENV_BIN)/postactivate
 	echo "unset PYTHONBREAKPOINT" > $(VENV_BIN)/predeactivate
 
-venv/bin/activate: requirements.txt
+venv/bin/python: requirements.txt
 	test -d venv || python3 -m venv venv
 	. venv/bin/activate \
 		&& pip install --upgrade pip setuptools \

--- a/{{cookiecutter.project_name}}/docs/source/_static/custom.css
+++ b/{{cookiecutter.project_name}}/docs/source/_static/custom.css
@@ -6,3 +6,8 @@ code.descname {
   color: #3cba54;
   }
 
+  cite {
+    color: #4885ed;
+    font-weight: bold;
+    font-style: normal;
+  }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

Description
-----------

<!-- Describe your changes in detail -->
Use a custom CSS file to emphasize keywords in the reference
documentation and keywords between backticks.

Drive-by:
* Fix the Makefile to prevent the venv target to run unnecessarily.


Motivation and Context
----------------------

<!-- Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here. -->

How Has This Been Tested?
-------------------------

<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran
to see how your change affects other areas of the code, etc. -->

Screenshots:
------------

<!-- Remove this section if not applicable. -->

Types of changes
----------------

<!-- What types of changes does your code introduce?
Select the choices apply: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Documentation

Checklist:
----------

<!-- Go over all the following points, and put an `x` in all the boxes
that apply. If you're unsure about any of these, don't hesitate to
ask. We're here to help! -->

-  [] I have updated the documentation accordingly.
-  [] I have written unit tests

<!-- Place the *FULL* URL of the issue here it this PR fixes an existing issue. -->